### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/anp_core/agent_connect/simple_node/simple_node_session.py
+++ b/anp_core/agent_connect/simple_node/simple_node_session.py
@@ -346,7 +346,7 @@ class SimpleNodeSession:
             return ''
 
         if json_data['secretKeyId'] != self.short_term_key['secret_key_id']:
-            logging.error(f"Key ID mismatch: {json_data['secretKeyId']} != {self.short_term_key['secret_key_id']}")
+            logging.error("Key ID mismatch detected between the received data and the expected key.")
             return ''
 
         encrypted_data = json_data['encryptedData']


### PR DESCRIPTION
Potential fix for [https://github.com/agent-network-protocol/anp-agent-openchat/security/code-scanning/3](https://github.com/agent-network-protocol/anp-agent-openchat/security/code-scanning/3)

The best way to fix this issue is to avoid logging the sensitive `secretKeyId` values directly. Instead, a more generic log message can be used to indicate a key mismatch without revealing the actual identifiers. For instance, the log message could simply state that a key mismatch occurred, without including the specific values.

To implement this fix:
1. Locate the problematic log message on line 349.
2. Replace the message to exclude the sensitive values (`json_data['secretKeyId']` and `self.short_term_key['secret_key_id']`).
3. Ensure the new log message provides sufficient context for debugging purposes without exposing sensitive data.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
