### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/anp_core/agent_connect/e2e_encryption/wss_message_sdk.py
+++ b/anp_core/agent_connect/e2e_encryption/wss_message_sdk.py
@@ -181,7 +181,7 @@ class WssMessageSDK:
         key_info = self.short_term_keys.get(secret_key_id, None)
 
         if key_info is None:
-            logging.error(f"Cannot find secret key info: {secret_key_id}")
+            logging.error("Cannot find secret key info")
             # TODO: Send error message later
             return
 


### PR DESCRIPTION
Potential fix for [https://github.com/agent-network-protocol/anp-agent-openchat/security/code-scanning/4](https://github.com/agent-network-protocol/anp-agent-openchat/security/code-scanning/4)

To fix the problem, replace the direct logging of `secret_key_id` with a generic message that does not include sensitive data. This ensures that no sensitive information is exposed in the logs while still providing useful debugging information.

**Steps:**
1. Replace `logging.error(f"Cannot find secret key info: {secret_key_id}")` with a generic error message, such as `"Cannot find secret key info"`.
2. No additional imports or definitions are required for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
