### PR TITLE
Potential fix for code scanning alert no. 15: Uncontrolled command line

### DIFF
--- a/web_anp_llmagent_launcher.py
+++ b/web_anp_llmagent_launcher.py
@@ -68,6 +68,13 @@ class ConnectionManager:
 manager = ConnectionManager()
 
 # 数据模型
+# 定义允许的命令
+ALLOWED_COMMANDS = {
+    "start": "start",
+    "stop": "stop",
+    "status": "status"
+}
+
 class InstanceCreate(BaseModel):
     command: str
     name: Optional[str] = None
@@ -95,7 +102,11 @@ def start_instance(command: str, instance_id: str, name: Optional[str] = None, p
         if not kill_processes_by_port(port):
             print(f"无法清理端口 {port}，启动实例可能会失败")
     
-    cmd = [sys.executable, os.path.join(user_dir, "anp_llmagent.py"), command]
+    # 验证命令是否合法
+    if command not in ALLOWED_COMMANDS:
+        raise ValueError(f"无效的命令: {command}")
+    
+    cmd = [sys.executable, os.path.join(user_dir, "anp_llmagent.py"), ALLOWED_COMMANDS[command]]
     
     if command == "agent" and name:
         # 修正：使用-u参数传递智能体名称
@@ -431,15 +442,10 @@ async def websocket_endpoint(websocket: WebSocket):
 # REST API
 @app.post("/api/instances", response_model=InstanceInfo)
 async def create_instance(instance: InstanceCreate):
-    instance_id = str(uuid.uuid4())
-    success = start_instance(
-        command=instance.command,
-        instance_id=instance_id,
-        name=instance.name,
-        port=instance.port,
-        did=instance.did,
-        url=instance.url
-    )
+    # 验证命令是否合法
+    if instance.command not in ALLOWED_COMMANDS:
+        raise HTTPException(status_code=400, detail=f"无效的命令: {instance.command}")
+    
     
     if not success:
         raise HTTPException(status_code=500, detail="启动实例失败")


### PR DESCRIPTION
Potential fix for [https://github.com/agent-network-protocol/anp-agent-openchat/security/code-scanning/15](https://github.com/agent-network-protocol/anp-agent-openchat/security/code-scanning/15)

The best way to fix this problem is to implement an allowlist of acceptable commands. This ensures that only predefined, safe commands can be executed. We will define a dictionary of allowed commands (like the example provided in the background section) and validate the user input against this allowlist.

Specifically:
1. Introduce a dictionary `ALLOWED_COMMANDS` mapping valid user inputs to their corresponding commands.
2. Modify the `start_instance` function to verify that the `command` argument is in the `ALLOWED_COMMANDS` dictionary. If not, raise an exception and avoid executing the command.
3. Update the REST API endpoint `/api/instances` to reflect this validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
